### PR TITLE
Add the possibility to instantiate many members at once

### DIFF
--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -1,8 +1,8 @@
 .. _howto-label:
 
-==========
-How to use
-==========
+=============
+General usage
+=============
 
 .. contents::
   :local:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,6 +5,10 @@
 PDFflow: Gotta go fast
 ======================
 
+.. contents::
+   :local:
+   :depth: 1
+
 PDFflow is a parton distribution function interpolation library written in Python and based on the `TensorFlow <https://www.tensorflow.org/>`_ framework.
 It is developed with a focus on speed and efficiency, enabling researchers to perform very expensive calculation as quick and easy as possible.
 
@@ -23,20 +27,20 @@ To that end PDFflow is based on two technologies that together will enable a new
     - `TensorFlow <https://www.tensorflow.org/>`_: the framework developed by Google and made public in November of 2015 is a perfect combination between performance and usability. With a focus on Deep Learning, TensorFlow provides an algebra library able to easily run operations in many different devices: CPUs, GPUs, TPUs with little input by the developer. Write your code once.
 
 
-FAQ
-===
-
 Why the name ``pdfflow``?
 ---------------------------
 
 It is a combination of the names `PDF` and `Tensorflow`.
 
 .. toctree::
-    :maxdepth: 3
-    :caption: Contents:
+   :maxdepth: 3
+   :glob:
+   :caption: Contents:
 
-    index
-    how_to
+   PDFFlow<self>
+   overview
+   how_to
+
 
 .. automodule:: pdfflow
     :members:

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -1,0 +1,46 @@
+.. _overview-label:
+
+========
+Overview
+========
+
+.. contents::
+   :local:
+   :depth: 1
+
+Instantiating a PDF
+-------------------
+PDFs can be instantiated in a similar manner to [``LHAPDF``](https://lhapdf.hepforge.org/)
+by calling the provided ``mkPDF`` and ``mkPDFs`` functions.
+
+If ``LHAPDF`` and the ``pdfset`` are installed in the system it is enough to call:
+
+.. code-block:: python
+
+  from pdfflow.pflow import mkPDF
+  pdf = mkPDF(f"{pdfset}/0")
+
+
+To obtain the central member (0) of the ``pdfset``.
+It is often necessary to require several members of a set, for instance to compute
+pdf error. This can be achieved with the ``mkPDFs`` function, for instance,
+to obtain members (0,1,2) we can do:
+
+.. code-block:: python
+
+  from pdfflow.pflow import mkPDF
+  pdf = mkPDFs(pdfset, [0, 1, 2])
+
+
+Note that both ``mkPDF`` and ``mkPDFs`` accept the keyword argument ``dirname``.
+If ``dirname`` is not provided, ``pdfflow`` will try to obtain the PDF directory
+from ``LHAPDF``.
+If ``dirname`` is provided, instead, ``pdfflow`` will load the pdffset from the given directory.
+These functions are all wrappers around the low-level ``PDF`` class and provide an instance to the class.
+The class can also be instantiated directly with:
+
+.. code-block:: python
+
+  from pdfflow.pflow import PDF
+  pdf = PDF(dirname, pdfset, [0]) # obtain a PDF instance for member 0
+  pdf = PDF(dirname, pdfset, [2, 5]) # obtain a PDF instance for members 2 and 5

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -28,7 +28,7 @@ to obtain members (0,1,2) we can do:
 
 .. code-block:: python
 
-  from pdfflow.pflow import mkPDF
+  from pdfflow.pflow import mkPDFs
   pdf = mkPDFs(pdfset, [0, 1, 2])
 
 

--- a/src/pdfflow/configflow.py
+++ b/src/pdfflow/configflow.py
@@ -13,6 +13,10 @@ import tensorflow as tf
 # uncomment this line for debugging to avoid compiling any tf.function
 # tf.config.run_functions_eagerly(True)
 
+def run_eager(flag = True):
+    """ Wraper around `run_functions_eagerly` """
+    tf.config.run_functions_eagerly(flag)
+
 # Configure pdfflow logging
 import logging
 

--- a/src/pdfflow/configflow.py
+++ b/src/pdfflow/configflow.py
@@ -11,7 +11,7 @@ os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")
 import tensorflow as tf
 
 # uncomment this line for debugging to avoid compiling any tf.function
-# tf.config.experimental_run_functions_eagerly(True)
+# tf.config.run_functions_eagerly(True)
 
 # Configure pdfflow logging
 import logging

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -300,7 +300,7 @@ class PDF:
         if len(self.grids) == 1:
             return res
         else:
-            return tf.stack(res)
+            return tf.stack(all_res)
 
     @tf.function(input_signature=[GRID_I, GRID_F, GRID_F])
     def xfxQ2(self, pid, a_x, a_q2):

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -551,6 +551,15 @@ class PDF:
             alphas: tensor
                 alphas evaluated in each q^2 query point
         """
+        # Check whether the array is a tensor
+        if not tf.is_tensor(a_q2):
+            logger.error(
+                "The `alphasQ2` method can only be called with tensorflow variables "
+                "use `py_alphasQ2` to obtain results with regular python variables "
+                "or use the functions `int_me` and `float_me` from pdfflow.configflow "
+                "to cast the input to tensorflow variables"
+            )
+            raise TypeError("alphasQ2 called with wrong types")
         return self._alphasQ2(a_q2)
 
     @tf.function(input_signature=[GRID_F])
@@ -569,13 +578,15 @@ class PDF:
             alphas: tensor
                 alphas evaluated in each q query point
         """
-        # Parse the input
-        # print('trace')
-        # a_q = float_me(arr_q)
-        a_q2 = tf.square(a_q)
-
-        # Perform the actual computation
-        return self._alphasQ2(a_q2)
+        if not tf.is_tensor(a_q):
+            logger.error(
+                "The `alphasQ` method can only be called with tensorflow variables "
+                "use `py_alphasQ` to obtain results with regular python variables "
+                "or use the functions `int_me` and `float_me` from pdfflow.configflow "
+                "to cast the input to tensorflow variables"
+            )
+            raise TypeError("alphasQ called with wrong types")
+        return self.alphasQ2(tf.square(a_q))
 
     def py_alphasQ2(self, arr_q2):
         """

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -107,8 +107,9 @@ def _load_alphas(info_file):
 
     return grids
 
+
 def mkPDFs(fname, members, dirname=None):
-    """ Wrapper to generate a multimember PDF
+    """Wrapper to generate a multimember PDF
     Needs a name and a directory where to find the grid files.
 
     Parameters
@@ -134,8 +135,9 @@ def mkPDFs(fname, members, dirname=None):
         dirname = dirname_raw.stdout.strip()
     return PDF(dirname, fname, members)
 
+
 def mkPDF(fname, dirname=None):
-    """ Wrapper to generate a PDF given a PDF name and a directory
+    """Wrapper to generate a PDF given a PDF name and a directory
     where to find the grid files.
 
     Parameters
@@ -252,7 +254,6 @@ class PDF:
             member = str(member_int).zfill(4)
             member_list.append(f"{self.fname}_{member}.dat")
         return member_list
-
 
     @tf.function(input_signature=[GRID_I, GRID_F, GRID_F])
     def _xfxQ2(self, u, arr_x, arr_q2):

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -355,7 +355,8 @@ class PDF:
         f_f = self._xfxQ2(pid_idx, a_x, a_q2)
 
         # Return the values in the order the user asked
-        f_f = tf.gather(f_f, user_idx, axis=1)
+        # the flavour axis here is the last one
+        f_f = tf.gather(f_f, user_idx, axis=-1)
 
         result = tf.squeeze(f_f)
         return result
@@ -544,19 +545,11 @@ class PDF:
         # Perform the actual computation
         return self.alphasQ(a_q)
 
-    def trace(self, all_members=False):
+    def trace(self):
         """
         Builds all the needed graph in advance of interpolations
-        Takes the central member as the target grid
-
-        If each member has a different grid size, use the flag `all_members`
-
-        Parameters
-        ---------
-            all_members: bool
-                Whether to build all members according to their own grids
         """
-        logger.info("Building tf.Graph ...")
+        logger.info("Building tf.Graph, this can take a while...")
         x = []
         q2 = []
 
@@ -588,18 +581,18 @@ class PDF:
         q2max = np.max(q2grids)
         q2min = np.min(q2grids)
 
-        xgrids.append((xmin*0.99, xmin))
-        xgrids.append((xmax, xmax*1.01))
-        q2grids.append((q2min*0.99, q2min))
-        q2grids.append((q2max, q2max*1.01))
+        xgrids.append((xmin * 0.99, xmin))
+        xgrids.append((xmax, xmax * 1.01))
+        q2grids.append((q2min * 0.99, q2min))
+        q2grids.append((q2max, q2max * 1.01))
 
         # Now create a set of points such that all x-grids are visited
         # for all grids in q2
         for xmin, xmax in xgrids:
-            xpoint = (xmax-xmin)/2.0
+            xpoint = (xmax - xmin) / 2.0
             for q2min, q2max in q2grids:
                 x.append(xpoint)
-                q2.append((q2max-q2min)/2.0)
+                q2.append((q2max - q2min) / 2.0)
 
         # Make into an array that can be called
         x = np.array(x)

--- a/src/pdfflow/tests/test_pflow.py
+++ b/src/pdfflow/tests/test_pflow.py
@@ -64,10 +64,8 @@ def test_multimember():
     run_eager(False)
     pdf = mkPDFs(PDFNAME, [0, 2, 4, 7])
     # Check the tracing with the central-member grid
+    pdf.trace()
     pdfflow_tester(pdf)
-    pdf = mkPDFs(PDFNAME, [3, 9])
-    # Check the tracing with all-members
-    pdfflow_tester(pdf, all_members=True)
 
 if __name__ == "__main__":
-    test_onemember()
+    test_multimember()

--- a/src/pdfflow/tests/test_pflow.py
+++ b/src/pdfflow/tests/test_pflow.py
@@ -4,47 +4,83 @@
     This file also checks that functions can indeed compile
 """
 from pdfflow.pflow import mkPDF, mkPDFs
-from pdfflow.configflow import run_eager
+from pdfflow.configflow import run_eager, int_me, float_me
 import logging
 
 logger = logging.getLogger("pdfflow.test")
 import os
 import subprocess as sp
+import numpy as np
 from pdfflow.tests.test_lhapdf import install_lhapdf
 
 # Run tests in CPU
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 import tensorflow as tf
 
-PDFNAME = "NNPDF31_nlo_as_0118"
+# PDFNAME = "NNPDF31_nlo_as_0118"
+PDFNAME = "NNPDF31_nlo_as_0118_1000"
 install_lhapdf(PDFNAME)
 
 
-def pdfflow_tester(pdf):
-    """ Test several pdfflow features:
-        - Instantiationg
-        - Calling it with different PID
+def pdfflow_tester(pdf, members=None):
+    """Test several pdfflow features:
+    - Check the single/many/all-pid signatures
+    - Checks the python and TF signatures
+    - Checks the output of the python and TF signatures are the same
+    - Checks the expected shape of the signatures is correct
     """
-    q2 = [16.7]
-    x = [0.5]
+    grid_size = 7
+    x = np.random.rand(grid_size)
+    q2 = 1000.0 * np.random.rand(grid_size)
+    xtf = float_me(x)
+    q2tf = float_me(q2)
     # Check I can get just one pid
     for i in range(-1, 2):
         # as int
-        pdf.py_xfxQ2(i, x, q2)
+        res_1 = pdf.py_xfxQ2(i, x, q2)
         # as list
-        pdf.py_xfxQ2([i], x, q2)
-        # check the tf signature
-        tfpid = tf.constant([i])
-        pdf.xfxQ2(tfpid, x, q2)
+        res_2 = pdf.py_xfxQ2([i], x, q2)
+        np.testing.assert_allclose(res_1, res_2)
+        # as tf objects
+        tfpid = int_me([i])
+        res_3 = pdf.xfxQ2(tfpid, xtf, q2tf)
+        np.testing.assert_allclose(res_2, res_3)
+
+        # Check shape
+        if members is None:
+            assert res_1.numpy().shape == (grid_size,)
+        else:
+            assert res_1.numpy().shape == (
+                members,
+                grid_size,
+            )
+
     # Check I can get more than one pid
-    pdf.py_xfxQ2([1, 4, -2, -1, 4], x, q2)
-    tfpid = tf.constant([1, 0, 21])
-    pdf.xfxQ2(tfpid, x, q2)
-    # Check I can ask for pid 21
-    pdf.py_xfxQ2(21, x, q2)
-    # or all pids
-    pdf.py_xfxQ2_allpid(x, q2)
-    pdf.xfxQ2_allpid(x, q2)
+    nfl_size = 6
+    fl_scheme = pdf.flavor_scheme.numpy()
+    nfl_total = fl_scheme.size
+    many_pid = np.random.choice(fl_scheme, nfl_size)
+
+    res_1 = pdf.py_xfxQ2(many_pid, x, q2)
+    res_2 = pdf.xfxQ2(int_me(many_pid), xtf, q2tf)
+    np.testing.assert_allclose(res_1, res_2)
+    # Check shape
+    if members is None:
+        assert res_1.numpy().shape == (grid_size, nfl_size)
+    else:
+        assert res_1.numpy().shape == (members, grid_size, nfl_size)
+
+    # Check I can actually get all PID
+    res_1 = pdf.py_xfxQ2_allpid(x, q2)
+    res_2 = pdf.xfxQ2_allpid(xtf, q2tf)
+
+    np.testing.assert_allclose(res_1, res_2)
+    # Check shape
+    if members is None:
+        assert res_1.numpy().shape == (grid_size, nfl_total)
+    else:
+        assert res_1.numpy().shape == (members, grid_size, nfl_total)
+
 
 def test_onemember():
     """ Test the one-central-member of pdfflow """
@@ -62,10 +98,24 @@ def test_onemember():
 def test_multimember():
     """ Test the multi-member capabilities of pdfflow """
     run_eager(False)
-    pdf = mkPDFs(PDFNAME, [0, 2, 4, 7])
-    # Check the tracing with the central-member grid
+    members = 5
+    pdf = mkPDFs(PDFNAME, range(members))
     pdf.trace()
-    pdfflow_tester(pdf)
+    pdfflow_tester(pdf, members=members)
+
+
+def test_one_multi():
+    """ Test that the multimember-I is indeed the same as just the Ith instance """
+    run_eager(True)
+    pdf = mkPDF(f"{PDFNAME}/0")
+    multi_pdf = mkPDFs(PDFNAME, [4, 0, 6])
+    grid_size = 4
+    x = np.random.rand(grid_size)
+    q2 = np.random.rand(grid_size) * 1000.0
+    res_1 = pdf.py_xfxQ2_allpid(x, q2)
+    res_2 = multi_pdf.py_xfxQ2_allpid(x, q2)
+    np.testing.assert_allclose(res_1, res_2[1])
+
 
 if __name__ == "__main__":
-    test_multimember()
+    test_one_multi()

--- a/src/pdfflow/tests/test_pflow.py
+++ b/src/pdfflow/tests/test_pflow.py
@@ -4,6 +4,7 @@
     This file also checks that functions can indeed compile
 """
 from pdfflow.pflow import mkPDF, mkPDFs
+from pdfflow.configflow import run_eager
 import logging
 
 logger = logging.getLogger("pdfflow.test")
@@ -20,8 +21,10 @@ install_lhapdf(PDFNAME)
 
 
 def pdfflow_tester(pdf):
-    """ Test several pdfflow features form instanciation to calling it
-    with different PID formats"""
+    """ Test several pdfflow features:
+        - Instantiationg
+        - Calling it with different PID
+    """
     q2 = [16.7]
     x = [0.5]
     # Check I can get just one pid
@@ -45,13 +48,26 @@ def pdfflow_tester(pdf):
 
 def test_onemember():
     """ Test the one-central-member of pdfflow """
+    # Check the central member
     pdf = mkPDF(f"{PDFNAME}/0")
     pdfflow_tester(pdf)
+    # Try a non-central member, but trace first
+    # Ensure it is not running eagerly
+    run_eager(False)
+    pdf = mkPDF(f"{PDFNAME}/1")
+    pdf.trace()
+    pdfflow_tester(pdf)
+
 
 def test_multimember():
     """ Test the multi-member capabilities of pdfflow """
+    run_eager(False)
     pdf = mkPDFs(PDFNAME, [0, 2, 4, 7])
+    # Check the tracing with the central-member grid
     pdfflow_tester(pdf)
+    pdf = mkPDFs(PDFNAME, [3, 9])
+    # Check the tracing with all-members
+    pdfflow_tester(pdf, all_members=True)
 
 if __name__ == "__main__":
-    test_multimember()
+    test_onemember()

--- a/src/pdfflow/tests/test_pflow.py
+++ b/src/pdfflow/tests/test_pflow.py
@@ -3,7 +3,7 @@
 
     This file also checks that functions can indeed compile
 """
-from pdfflow.pflow import mkPDF
+from pdfflow.pflow import mkPDF, mkPDFs
 import logging
 
 logger = logging.getLogger("pdfflow.test")
@@ -19,10 +19,9 @@ PDFNAME = "NNPDF31_nlo_as_0118"
 install_lhapdf(PDFNAME)
 
 
-def test_pflow():
+def pdfflow_tester(pdf):
     """ Test several pdfflow features form instanciation to calling it
     with different PID formats"""
-    pdf = mkPDF(f"{PDFNAME}/0")
     q2 = [16.7]
     x = [0.5]
     # Check I can get just one pid
@@ -44,6 +43,15 @@ def test_pflow():
     pdf.py_xfxQ2_allpid(x, q2)
     pdf.xfxQ2_allpid(x, q2)
 
+def test_onemember():
+    """ Test the one-central-member of pdfflow """
+    pdf = mkPDF(f"{PDFNAME}/0")
+    pdfflow_tester(pdf)
+
+def test_multimember():
+    """ Test the multi-member capabilities of pdfflow """
+    pdf = mkPDFs(PDFNAME, [0, 2, 4, 7])
+    pdfflow_tester(pdf)
 
 if __name__ == "__main__":
-    test_pflow()
+    test_multimember()


### PR DESCRIPTION
This should help with issue #33 as well as with the fktable benchmark.

For single-member PDFs (which is the standard way of using it) there should be no difference.

Right now is pointing to #30, the reason being that the `trace` stuff will need some changes in order to work with it (since I guess technically each PDF members could have a different x-grid) so #30 needs to be merged, then a few more changes to this PR and it will be ready for merging.