### PR TITLE
Add control of type from the environment

### DIFF
--- a/doc/source/how_to.rst
+++ b/doc/source/how_to.rst
@@ -53,6 +53,8 @@ the `nvidia official documentation <https://docs.nvidia.com/deeplearning/framewo
 - ``TF_CPP_MIN_LOG_LEVEL``: controls the ``TensorFlow`` logging level. It is set to 1 by default so that only errors are printed.
 - ``PDFFLOW_LOG_LEVEL``: controls the ``PDFFlow`` logging level. Set to 3 by default so that everything is printed.
 - ``CUDA_VISIBLE_DEVICES``: set the devices that are visible for ``TensorFlow``. If unset it will try to use all GPUs available. In order to force the code to run on CPU it needs to be set to ``""``. In a multi-GPU system you can choose, by index, the GPUs available for ``TensorFlow``, e.g. ``export CUDA_VISIBLE_DEVICES=0,1``.
+- ``PDFFLOW_FLOAT``: controls the ``PDFFlow`` float precision. Default is 64 for 64-bits. Accepts: 64, 32.
+- ``PDFFLOW_INT``: controls the ``PDFFlow`` integer precision. Default is 32 for 32-bits. Accepts: 64, 32.
 
 
 Building the graph ahead of time

--- a/src/pdfflow/configflow.py
+++ b/src/pdfflow/configflow.py
@@ -50,8 +50,23 @@ if bad_log_warning is not None:
     logger.warning(f"Setting log level to its default value: {DEFAULT_LOG_LEVEL}")
 
 # Define the tensorflow number types
-DTYPE = tf.float64
-DTYPEINT = tf.int32
+_float_env = os.environ.get("PDFFLOW_FLOAT", "64")
+_int_env = os.environ.get("PDFFLOW_INT", "32")
+
+if _float_env == "64":
+    DTYPE = tf.float64
+elif _float_env == "32":
+    DTYPE = tf.float32
+else:
+    logger.warning(f"PDFFLOW_FLOAT={_float_env} not understood, defaulting to 64 bits")
+
+if _int_env == "64":
+    DTYPEINT = tf.int64
+elif _int_env == "32":
+    DTYPEINT = tf.int32
+else:
+    logger.warning(f"PDFFLOW_INT={_int_env} not understood, defaulting to 64 bits")
+
 FMAX = tf.constant(np.finfo(np.float64).max, dtype=DTYPE)
 
 # The wrappers below transform tensors and array to the correct type

--- a/src/pdfflow/tests/test_config.py
+++ b/src/pdfflow/tests/test_config.py
@@ -1,0 +1,51 @@
+"""
+    Test that the configuration is consistent
+"""
+
+import os
+import numpy as np
+import importlib
+import pdfflow.configflow
+from pdfflow.configflow import DTYPE, DTYPEINT, int_me, float_me
+
+
+def test_int_me():
+    res = int_me(4)
+    assert res.dtype == DTYPEINT
+
+
+def test_float_me():
+    res = float_me(4.0)
+    assert res.dtype == DTYPE
+
+
+def test_float_env():
+    os.environ["PDFFLOW_FLOAT"] = "32"
+    importlib.reload(pdfflow.configflow)
+    from pdfflow.configflow import DTYPE
+
+    assert DTYPE.as_numpy_dtype == np.float32
+    os.environ["PDFFLOW_FLOAT"] = "64"
+    importlib.reload(pdfflow.configflow)
+    from pdfflow.configflow import DTYPE
+
+    assert DTYPE.as_numpy_dtype == np.float64
+    # Reset to default
+    os.environ["PDFFLOW_FLOAT"] = "64"
+    importlib.reload(pdfflow.configflow)
+
+
+def test_int_env():
+    os.environ["PDFFLOW_INT"] = "32"
+    importlib.reload(pdfflow.configflow)
+    from pdfflow.configflow import DTYPEINT
+
+    assert DTYPEINT.as_numpy_dtype == np.int32
+    os.environ["PDFFLOW_INT"] = "64"
+    importlib.reload(pdfflow.configflow)
+    from pdfflow.configflow import DTYPEINT
+
+    assert DTYPEINT.as_numpy_dtype == np.int64
+    # Reset to default
+    os.environ["PDFFLOW_INT"] = "32"
+    importlib.reload(pdfflow.configflow)


### PR DESCRIPTION
Now the `DTYPE` and `DTYPEINT` variables can be controlled using the `PDFFLOW_INT` and `PDFFLOW_FLOAT` environment variables.