### PR TITLE
fix benchmarks

### DIFF
--- a/benchmarks/compare_accuracy_alphas.py
+++ b/benchmarks/compare_accuracy_alphas.py
@@ -16,6 +16,8 @@ from compare_accuracy_lhapdf import set_ticks
 parser = argparse.ArgumentParser()
 parser.add_argument("--pdfname", "-p", default="NNPDF31_nlo_as_0118/0",
                     type=str, help='The PDF set name/replica number.')
+parser.add_argument("--no_latex", action="store_true",
+                    help="Don't use latex to render plots")
 DIRNAME = sp.run(['lhapdf-config','--datadir'], stdout=sp.PIPE,
                  universal_newlines=True).stdout.strip('\n') + '/'
 EPS = np.finfo(float).eps
@@ -76,9 +78,11 @@ def compare_alphas(pdfname, ax):
     return ax
 
 
-def main(pdfname):
+def main(pdfname, no_latex=False):
     """Testing PDFflow vs LHAPDF performance."""
-    mpl.rcParams['text.usetex'] = True
+    if not no_latex:
+        mpl.rcParams['text.usetex'] = True
+
     mpl.rcParams['savefig.format'] = 'pdf'
     mpl.rcParams['figure.figsize'] = [11,5.5]
     mpl.rcParams['axes.titlesize'] = 20

--- a/benchmarks/compare_accuracy_alphas.py
+++ b/benchmarks/compare_accuracy_alphas.py
@@ -16,8 +16,6 @@ from compare_accuracy_lhapdf import set_ticks
 parser = argparse.ArgumentParser()
 parser.add_argument("--pdfname", "-p", default="NNPDF31_nlo_as_0118/0",
                     type=str, help='The PDF set name/replica number.')
-parser.add_argument("--no_latex", action="store_true",
-                    help="Don't use latex to render plots")
 DIRNAME = sp.run(['lhapdf-config','--datadir'], stdout=sp.PIPE,
                  universal_newlines=True).stdout.strip('\n') + '/'
 EPS = np.finfo(float).eps
@@ -78,10 +76,9 @@ def compare_alphas(pdfname, ax):
     return ax
 
 
-def main(pdfname, no_latex=False):
+def main(pdfname):
     """Testing PDFflow vs LHAPDF performance."""
-    if not no_latex:
-        mpl.rcParams['text.usetex'] = True
+    mpl.rcParams['text.usetex'] = True
 
     mpl.rcParams['savefig.format'] = 'pdf'
     mpl.rcParams['figure.figsize'] = [11,5.5]

--- a/benchmarks/compare_accuracy_lhapdf.py
+++ b/benchmarks/compare_accuracy_lhapdf.py
@@ -17,8 +17,6 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--pdfname", "-p", default="NNPDF31_nlo_as_0118/0",
                     type=str, help='The PDF set name/replica number.')
 parser.add_argument("--pid", default=21, type=int, help='The flavour PID.')
-parser.add_argument("--no_latex", action="store_true",
-                    help="Don't use latex to render plots")
 DIRNAME = sp.run(['lhapdf-config','--datadir'], stdout=sp.PIPE,
                  universal_newlines=True).stdout.strip('\n') + '/'
 EPS = np.finfo(float).eps
@@ -73,10 +71,9 @@ def set_ticks(ax, start, end, numticks, axis, nskip=2):
     return ax    
     
 
-def main(pdfname, pid, no_latex=False):
+def main(pdfname, pid):
     """Testing PDFflow vs LHAPDF performance."""
-    if not no_latex:
-        mpl.rcParams['text.usetex'] = True
+    mpl.rcParams['text.usetex'] = True
     mpl.rcParams['savefig.format'] = 'pdf'
     mpl.rcParams['figure.figsize'] = [11,5.5]
     mpl.rcParams['axes.titlesize'] = 20

--- a/benchmarks/compare_accuracy_lhapdf.py
+++ b/benchmarks/compare_accuracy_lhapdf.py
@@ -17,6 +17,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--pdfname", "-p", default="NNPDF31_nlo_as_0118/0",
                     type=str, help='The PDF set name/replica number.')
 parser.add_argument("--pid", default=21, type=int, help='The flavour PID.')
+parser.add_argument("--no_latex", action="store_true",
+                    help="Don't use latex to render plots")
 DIRNAME = sp.run(['lhapdf-config','--datadir'], stdout=sp.PIPE,
                  universal_newlines=True).stdout.strip('\n') + '/'
 EPS = np.finfo(float).eps
@@ -71,9 +73,10 @@ def set_ticks(ax, start, end, numticks, axis, nskip=2):
     return ax    
     
 
-def main(pdfname, pid):
+def main(pdfname, pid, no_latex=False):
     """Testing PDFflow vs LHAPDF performance."""
-    mpl.rcParams['text.usetex'] = True
+    if not no_latex:
+        mpl.rcParams['text.usetex'] = True
     mpl.rcParams['savefig.format'] = 'pdf'
     mpl.rcParams['figure.figsize'] = [11,5.5]
     mpl.rcParams['axes.titlesize'] = 20

--- a/benchmarks/compare_performance_lhapdf.py
+++ b/benchmarks/compare_performance_lhapdf.py
@@ -31,8 +31,8 @@ parser.add_argument("--label0", default=None, type=str,
 parser.add_argument("--label1", default=None, type=str,
                     help=" ".join(["Legend label of second pdfflow running device,",
                                     "defaults to tf device auto selection"]))
-
-
+parser.add_argument("--no_latex", action="store_true",
+                    help="Don't use latex to render plots")
 DIRNAME = (sp.run(["lhapdf-config", "--datadir"], stdout=sp.PIPE,
            universal_newlines=True).stdout.strip("\n") + "/")
 
@@ -71,10 +71,10 @@ def accumulate_times(pdfname, dev0, dev1, no_lhapdf):
     else:
         l_pdf = None
 
-    xmin = np.exp(p0.subgrids[0].log_xmin)
-    xmax = np.exp(p0.subgrids[0].log_xmax)
-    q2min = np.sqrt(np.exp(p0.subgrids[0].log_q2min))
-    q2max = np.sqrt(np.exp(p0.subgrids[-1].log_q2max))
+    xmin = np.exp(p0.grids[0][0].log_xmin)
+    xmax = np.exp(p0.grids[0][0].log_xmax)
+    q2min = np.sqrt(np.exp(p0.grids[0][0].log_q2min))
+    q2max = np.sqrt(np.exp(p0.grids[0][-1].log_q2max))
 
     t_pdf0 = []
     t_pdf1 = []
@@ -113,7 +113,7 @@ def accumulate_times(pdfname, dev0, dev1, no_lhapdf):
 
 def main(pdfname=None, n_draws=10, pid=21, no_lhapdf=False,
          tensorboard=False, dev0=None, dev1=None,
-         label0=None, label1=None):
+         label0=None, label1=None, no_latex=False):
     """Testing PDFflow vs LHAPDF performance."""
     if tensorboard:
         tf.profiler.experimental.start('logdir')
@@ -132,7 +132,8 @@ def main(pdfname=None, n_draws=10, pid=21, no_lhapdf=False,
 
     import matplotlib.pyplot as plt
     import matplotlib as mpl
-    mpl.rcParams['text.usetex'] = True
+    if not no_latex:
+        mpl.rcParams['text.usetex'] = True
     mpl.rcParams['savefig.format'] = 'pdf'
     mpl.rcParams['figure.figsize'] = [7,8]
     mpl.rcParams['axes.titlesize'] = 20

--- a/benchmarks/compare_performance_lhapdf.py
+++ b/benchmarks/compare_performance_lhapdf.py
@@ -31,8 +31,6 @@ parser.add_argument("--label0", default=None, type=str,
 parser.add_argument("--label1", default=None, type=str,
                     help=" ".join(["Legend label of second pdfflow running device,",
                                     "defaults to tf device auto selection"]))
-parser.add_argument("--no_latex", action="store_true",
-                    help="Don't use latex to render plots")
 DIRNAME = (sp.run(["lhapdf-config", "--datadir"], stdout=sp.PIPE,
            universal_newlines=True).stdout.strip("\n") + "/")
 
@@ -113,7 +111,7 @@ def accumulate_times(pdfname, dev0, dev1, no_lhapdf):
 
 def main(pdfname=None, n_draws=10, pid=21, no_lhapdf=False,
          tensorboard=False, dev0=None, dev1=None,
-         label0=None, label1=None, no_latex=False):
+         label0=None, label1=None):
     """Testing PDFflow vs LHAPDF performance."""
     if tensorboard:
         tf.profiler.experimental.start('logdir')
@@ -132,8 +130,7 @@ def main(pdfname=None, n_draws=10, pid=21, no_lhapdf=False,
 
     import matplotlib.pyplot as plt
     import matplotlib as mpl
-    if not no_latex:
-        mpl.rcParams['text.usetex'] = True
+    mpl.rcParams['text.usetex'] = True
     mpl.rcParams['savefig.format'] = 'pdf'
     mpl.rcParams['figure.figsize'] = [7,8]
     mpl.rcParams['axes.titlesize'] = 20

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -193,7 +193,7 @@ class PDF:
 
         for member_int in members:
             member = str(member_int).zfill(4)
-            filename = os.path.join(self.dirname, fname, f'{fname}_{member}.dat')
+            filename = os.path.join(self.dirname, fname, f"{fname}_{member}.dat")
 
             logger.info("loading %s", filename)
             grids = _load_data(filename)
@@ -228,7 +228,7 @@ class PDF:
 
         # now load metadata from info file
         logger.info("Enabling computation of alpha")
-        self.fname = os.path.join(self.dirname, fname, f'{fname}.info')
+        self.fname = os.path.join(self.dirname, fname, f"{fname}.info")
 
         logger.info("loading %s", self.fname)
         alpha_grids = _load_alphas(self.fname)

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -8,6 +8,8 @@ import yaml
 import subprocess as sp
 import numpy as np
 
+import os
+
 try:
     import lhapdf
 except ModuleNotFoundError:
@@ -191,7 +193,7 @@ class PDF:
 
         for member_int in members:
             member = str(member_int).zfill(4)
-            filename = f"{self.dirname}/{fname}/{fname}_{member}.dat"
+            filename = os.path.join(self.dirname, fname, f'{fname}_{member}.dat')
 
             logger.info("loading %s", filename)
             grids = _load_data(filename)
@@ -226,7 +228,7 @@ class PDF:
 
         # now load metadata from info file
         logger.info("Enabling computation of alpha")
-        self.fname = f"{self.dirname}/{fname}/{fname}.info"
+        self.fname = os.path.join(self.dirname, fname, f'{fname}.info')
 
         logger.info("loading %s", self.fname)
         alpha_grids = _load_alphas(self.fname)


### PR DESCRIPTION
I realized that the benchmark wasn't working after changing an attribute's name in the Subgrid class. So this is fixed

Then I thought that these benchmarks don't work if latex is not installed on the machine. Then either we include latex in the requirements, or we include a switch that enable changing from latex to non-latex plot outputs.

If you have better solution, please tell me.
Thanks