### PR TITLE
Fix python < 3.7 compatibility issues

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.5, 3.6, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,9 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
+      max-parallel: 3
       matrix:
-        python-version: [3.7]
+        python-version: [3.5, 3.6, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='pdfflow',
             'sphinxcontrib-bibtex',
             ],
           },
-      python_requires='>=3.7',
+      python_requires='>=3.5',
       long_description=long_description,
       long_description_content_type="text/markdown",
 )

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='pdfflow',
             'sphinxcontrib-bibtex',
             ],
           },
-      python_requires='>=3.5',
+      python_requires='>=3.6',
       long_description=long_description,
       long_description_content_type="text/markdown",
 )

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -8,7 +8,7 @@ import yaml
 import subprocess as sp
 import numpy as np
 
-import os
+import os, sys
 
 try:
     import lhapdf
@@ -131,10 +131,14 @@ def mkPDFs(fname, members, dirname=None):
     if dirname is None:
         if lhapdf is None:
             raise ValueError("mkPDF needs a PDF name if lhapdf-python is not installed")
-        dirname_raw = sp.run(
-            ["lhapdf-config", "--datadir"], capture_output=True, text=True, check=True
-        )
-        dirname = dirname_raw.stdout.strip()
+        lhapdf_cmd = ["lhapdf-config", "--datadir"]
+        # Check the python version in order to use the right subprocess call
+        if sys.version_info.major == 3 and sys.version_info.minor < 7:
+            dirname_raw = sp.run(lhapdf_cmd, check=True, stdout=sp.PIPE)
+            dirname = dirname_raw.stdout.decode().strip()
+        else:
+            dirname_raw = sp.run(lhapdf_cmd, capture_output=True, text=True, check=True)
+            dirname = dirname_raw.stdout.strip()
     return PDF(dirname, fname, members)
 
 


### PR DESCRIPTION
Given that it was just a call to `subprocess.run` I thought it made sense to fix it so that people using very old versions of Debian or Cent OS can also use pdfflow.