### PR TITLE
Enable python 3.9

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         conda info
         python -m pip install --upgrade pip
-        pip install . --pre
+        pip install .
         conda install -y lhapdf -c https://packages.nnpdf.science/conda
     - name: Test with pytest
       shell: bash --login {0}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         conda info
         python -m pip install --upgrade pip
-        pip install .
+        pip install . --pre
         conda install -y lhapdf -c https://packages.nnpdf.science/conda
     - name: Test with pytest
       shell: bash --login {0}

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 # Installation script for python
 from setuptools import setup, find_packages
+from sys import version_info
 import os
 import re
 
 
-requirements = ['numpy', 'pyyaml', 'tensorflow>2.1']
+requirements = ['numpy', 'pyyaml']
+if version_info.major >=3 and version_info.minor >= 9:
+    # For python above 3.9 the only existing TF is 2.5 which works well (even pre releases)
+    tf_pack = "tensorflow"
+else:
+    tf_pack = "tensorflow>2.1"
+requirements.append(tf_pack)
 
 PACKAGE = 'pdfflow'
 

--- a/src/pdfflow/__init__.py
+++ b/src/pdfflow/__init__.py
@@ -4,4 +4,4 @@
 from pdfflow.configflow import int_me, float_me, run_eager
 from pdfflow.pflow import mkPDF, mkPDFs
 
-__version__ = "1.1"
+__version__ = "1.2"


### PR DESCRIPTION
Since [Tensorflow](https://github.com/tensorflow/tensorflow/releases/tag/v2.5.0-rc1) has python support and there are now two releases candidates in pip I guess it makes sense to at least enable the tests and check whether something breaks.

Deals with #51 