### PR TITLE
Add a PDFFLOW_DATA_PATH

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,9 +24,17 @@ jobs:
         conda info
         python -m pip install --upgrade pip
         pip install .
+        # Install LHAPDF
         conda install -y lhapdf -c https://packages.nnpdf.science/conda
+        # Download and install a PDF set to ensure that the environment paths are working
+        wget http://pcteserver.mi.infn.it/~nnpdf/nnpdf31/NNPDF31_nnlo_as_0118.tar.gz
+        mkdir -p pdfsets
+        tar xvfz NNPDF31_nnlo_as_0118.tar.gz
+        mv NNPDF31_nnlo_as_0118 pdfsets/
     - name: Test with pytest
       shell: bash --login {0}
       run: |
+        # Download the PDF set
+        export PDFFLOW_DATA_PATH="pdfsets"
         pip install pytest
         pytest

--- a/src/pdfflow/configflow.py
+++ b/src/pdfflow/configflow.py
@@ -1,64 +1,70 @@
 """
-Define some constants, header style
+    Encapsulate the definition of constant, logging behaviour and environment variables in one single module
 """
-# Most of this can be moved to a yaml file without loss of generality
 import os
 import logging
 import numpy as np
 
-# Set TF to only log errors
+# Log levels
+LOG_DICT = {"0": logging.ERROR, "1": logging.WARNING, "2": logging.INFO, "3": logging.DEBUG}
+
+# Read the PDFFLOW environment variables
+_log_level_idx = os.environ.get("PDFFLOW_LOG_LEVEL")
+_float_env = os.environ.get("PDFFLOW_FLOAT", "64")
+_int_env = os.environ.get("PDFFLOW_INT", "32")
+
+# Logging
+_bad_log_warning = None
+if _log_level_idx not in LOG_DICT:
+    _bad_log_warning = _log_level_idx
+    _log_level_idx = None
+
+if _log_level_idx is None:
+    # If no log level is provided, set some defaults
+    _log_level = LOG_DICT["2"]
+    _tf_log_level = LOG_DICT["0"]
+else:
+    _log_level = _tf_log_level = LOG_DICT[_log_level_idx]
+
+# Configure pdfflow logging
+logger = logging.getLogger(__name__.split(".")[0])
+logger.setLevel(_log_level)
+
+# Create and format the log handler
+_console_handler = logging.StreamHandler()
+_console_handler.setLevel(_log_level)
+_console_format = logging.Formatter("[%(levelname)s] (%(name)s) %(message)s")
+_console_handler.setFormatter(_console_format)
+logger.addHandler(_console_handler)
+
+# pdfflow options set, now import tensorfow to prepare convenience wrappers
+# and set any options that we need
 os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")
 import tensorflow as tf
 
-# uncomment this line for debugging to avoid compiling any tf.function
-# tf.config.run_functions_eagerly(True)
+tf.get_logger().setLevel(_tf_log_level)
+
 
 def run_eager(flag=True):
-    """ Wrapper around `run_functions_eagerly` """
-    if tf.__version__ < '2.3.0':
+    """Wrapper around `run_functions_eagerly`
+    When used no function is compiled
+    """
+    if tf.__version__ < "2.3.0":
         tf.config.experimental_run_functions_eagerly(flag)
     else:
         tf.config.run_functions_eagerly(flag)
 
-# Configure pdfflow logging
-module_name = __name__.split(".")[0]
-logger = logging.getLogger(module_name)
 
-# Read the log level from environment, 3 == debug, 2 (default) == info, 1 == warning, 0 == error
-DEFAULT_LOG_LEVEL = "2"
-log_level_idx = os.environ.get("PDFFLOW_LOG_LEVEL", DEFAULT_LOG_LEVEL)
-log_dict = {"0": logging.ERROR, "1": logging.WARNING, "2": logging.INFO, "3": logging.DEBUG}
-bad_log_warning = None
-if log_level_idx not in log_dict:
-    bad_log_warning = log_level_idx
-    log_level_idx = DEFAULT_LOG_LEVEL
-log_level = log_dict[log_level_idx]
-
-# Set level debug for development
-logger.setLevel(log_level)
-# Create a handler and format it
-console_handler = logging.StreamHandler()
-console_handler.setLevel(log_level)
-console_format = logging.Formatter("[%(levelname)s] (%(name)s) %(message)s")
-console_handler.setFormatter(console_format)
-logger.addHandler(console_handler)
-
-# Now that the logging has been created, warn about the bad logging level
-if bad_log_warning is not None:
-    logger.warning(
-        "Accepted log levels are: %s, received: %s", list(log_dict.keys()), bad_log_warning
-    )
-    logger.warning(f"Setting log level to its default value: {DEFAULT_LOG_LEVEL}")
-
-# Define the tensorflow number types
-_float_env = os.environ.get("PDFFLOW_FLOAT", "64")
-_int_env = os.environ.get("PDFFLOW_INT", "32")
-
+# set the precision type
 if _float_env == "64":
     DTYPE = tf.float64
+    FMAX = tf.constant(np.finfo(np.float64).max, dtype=DTYPE)
 elif _float_env == "32":
     DTYPE = tf.float32
+    FMAX = tf.constant(np.finfo(np.float32).max, dtype=DTYPE)
 else:
+    DTYPE = tf.float64
+    FMAX = tf.constant(np.finfo(np.float64).max, dtype=DTYPE)
     logger.warning(f"PDFFLOW_FLOAT={_float_env} not understood, defaulting to 64 bits")
 
 if _int_env == "64":
@@ -66,18 +72,17 @@ if _int_env == "64":
 elif _int_env == "32":
     DTYPEINT = tf.int32
 else:
+    DTYPEINT = tf.int64
     logger.warning(f"PDFFLOW_INT={_int_env} not understood, defaulting to 64 bits")
-
-FMAX = tf.constant(np.finfo(np.float64).max, dtype=DTYPE)
 
 # The wrappers below transform tensors and array to the correct type
 def int_me(i):
-    """ Cast the input to the `DTYPEINT` type """
+    """Cast the input to the `DTYPEINT` type"""
     return tf.cast(i, dtype=DTYPEINT)
 
 
 def float_me(i):
-    """ Cast the input to the `DTYPE` type """
+    """Cast the input to the `DTYPE` type"""
     return tf.cast(i, dtype=DTYPE)
 
 

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -18,7 +18,7 @@ import numpy as np
 import os, sys
 
 # import configflow before tf to set some tf options
-from pdfflow.configflow import DTYPE, DTYPEINT, int_me, izero, float_me
+from pdfflow.configflow import DTYPE, DTYPEINT, int_me, izero, float_me, find_pdf_path
 import tensorflow as tf
 from pdfflow.subgrid import Subgrid
 

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -17,11 +17,6 @@ import numpy as np
 
 import os, sys
 
-try:
-    import lhapdf
-except ModuleNotFoundError:
-    lhapdf = None
-
 # import configflow before tf to set some tf options
 from pdfflow.configflow import DTYPE, DTYPEINT, int_me, izero, float_me
 import tensorflow as tf
@@ -133,16 +128,10 @@ def mkPDFs(fname, members=None, dirname=None):
             instantiated member of the PDF class
     """
     if dirname is None:
-        if lhapdf is None:
-            raise ValueError("mkPDF needs a directory path if lhapdf-python is not installed")
-        lhapdf_cmd = ["lhapdf-config", "--datadir"]
-        # Check the python version in order to use the right subprocess call
-        if sys.version_info.major == 3 and sys.version_info.minor < 7:
-            dirname_raw = sp.run(lhapdf_cmd, check=True, stdout=sp.PIPE)
-            dirname = dirname_raw.stdout.decode().strip()
-        else:
-            dirname_raw = sp.run(lhapdf_cmd, capture_output=True, text=True, check=True)
-            dirname = dirname_raw.stdout.strip()
+        try:
+            dirname = find_pdf_path(fname)
+        except ValueError as e:
+            raise ValueError(f"mkPDFs need a directory") from e
     return PDF(dirname, fname, members)
 
 

--- a/src/pdfflow/tests/test_alphas.py
+++ b/src/pdfflow/tests/test_alphas.py
@@ -7,9 +7,13 @@ import os
 import logging
 import subprocess as sp
 import numpy as np
-import lhapdf
 import pdfflow.pflow as pdf
 from pdfflow.configflow import run_eager
+
+try:
+    import lhapdf
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError("Tests of alpha_s need an installation of LHAPDF")
 
 logger = logging.getLogger("pdfflow.test")
 

--- a/src/pdfflow/tests/test_lhapdf.py
+++ b/src/pdfflow/tests/test_lhapdf.py
@@ -11,9 +11,13 @@ logger = logging.getLogger("pdfflow.test")
 import os
 # Run tests in CPU
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
-import lhapdf
 import numpy as np
 import subprocess as sp
+
+try:
+    import lhapdf
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError("Tests against alpha_s need an installation of LHAPDF")
 
 # Utility to install lhapdf sets
 def install_lhapdf(pdfset):

--- a/src/pdfflow/tests/test_pflow.py
+++ b/src/pdfflow/tests/test_pflow.py
@@ -2,6 +2,10 @@
     Checks pdflow can run with no errors
 
     This file also checks that functions can indeed compile
+
+    Note that this test file does not install LHAPDF and (should)
+    use a PDF set that is not installed by any other test.
+    This ensures that pdfflow can indeed run independently of LHAPDF
 """
 from pdfflow.pflow import mkPDF, mkPDFs
 from pdfflow.configflow import run_eager, int_me, float_me
@@ -11,15 +15,12 @@ logger = logging.getLogger("pdfflow.test")
 import os
 import subprocess as sp
 import numpy as np
-from pdfflow.tests.test_lhapdf import install_lhapdf
 
 # Run tests in CPU
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 import tensorflow as tf
 
-# PDFNAME = "NNPDF31_nlo_as_0118"
-PDFNAME = "NNPDF31_nlo_as_0118_1000"
-install_lhapdf(PDFNAME)
+PDFNAME = "NNPDF31_nnlo_as_0118"
 
 
 def pdfflow_tester(pdf, members=None):


### PR DESCRIPTION
In a way similar to `LHAPDF`, this partially deals with #52, so that one can download pdf sets in some folder and have a `PDFFLOW_DATA_PATH` variable, similar to `LHAPDF_DATA_PATH` (actually, that one works as well) and not need to install `lhapdf`.