### PR TITLE
Remove LHAPDF non-python dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ TensorFlow is updated frequently and a later version of TensorFlow will often
 offer better performance in both GPUs and CPUs.
 Although it can be made to work with earlier versions, `PDFFlow` is only supported for TensorFlow>2.1.
 
+## PDF set management
+
+PDFFlow does not do management of PDF sets, which is left to LHAPDF and so a lhapdf installation is needed.
+A full lhapdf installation can be obtained by utilizing the `lhapdf_management` library.
+
+```bash
+  python3 -m pip install lhapdf_management
+  lhapdf_management install NNPDF31_nnlo_as_0118
+```
+
 ## Minimal Working Example
 
 Below a minimalistic example where `PDFFlow` is used to generate a 10 values of the PDF

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 
 
-requirements = ['numpy', 'pyyaml']
+requirements = ['numpy', 'pyyaml', 'lhapdf_management']
 if version_info.major >=3 and version_info.minor >= 9:
     # For python above 3.9 the only existing TF is 2.5 which works well (even pre releases)
     tf_pack = "tensorflow"

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import os, sys
 
-from pdfflow_management.pdfset import PDF as LHA_PDF
+from lhapdf_management.pdfsets import PDF as LHA_PDF
 
 # import configflow before tf to set some tf options
 from pdfflow.configflow import DTYPE, DTYPEINT, int_me, izero, float_me, find_pdf_path
@@ -164,7 +164,7 @@ class PDF:
             logger.info("Loading %d members from %s", len(members), self.fname)
 
         for member_int in members:
-            grids = pdf.get_member_grids(member)
+            grids = lhapdf_pdf.get_member_grids(member_int)
             subgrids = [Subgrid(grid, i, len(grids)) for i, grid in enumerate(grids)]
             self.grids.append(subgrids)
         self.members = members

--- a/src/pdfflow/pflow.py
+++ b/src/pdfflow/pflow.py
@@ -11,11 +11,14 @@
 import logging
 import collections
 import yaml
+from pathlib import Path
 
 import subprocess as sp
 import numpy as np
 
 import os, sys
+
+from pdfflow_management.pdfset import PDF as LHA_PDF
 
 # import configflow before tf to set some tf options
 from pdfflow.configflow import DTYPE, DTYPEINT, int_me, izero, float_me, find_pdf_path
@@ -32,44 +35,6 @@ logger = logging.getLogger(__name__)
 # create the Grid namedtuple
 GridTuple = collections.namedtuple("Grid", ["x", "q2", "flav", "grid"])
 AlphaTuple = collections.namedtuple("Alpha", ["q2", "grid"])
-
-
-def _load_data(pdf_file):
-    """
-    Reads pdf from file and retrieves a list of grids
-    Each grid is a tuple containing numpy arrays (x,Q2, flavours, pdf)
-
-    Note:
-        the input q array in LHAPDF is just q, this functions
-        squares the result and q^2 is used everwhere in the code
-
-    Parameters
-    ----------
-        pdf_file: str
-            PDF .dat file
-
-    Returns
-    -------
-        grids: list(tuple(np.array))
-            list of tuples of arrays (x, Q2, flavours, pdf values)
-    """
-    with open(pdf_file, "r") as pfile:
-        n = []
-        count = 0
-        for line in pfile:
-            if "---" in line:
-                n += [count]
-            count += 1
-
-    grids = []
-    for i in range(len(n) - 1):
-        x = np.loadtxt(pdf_file, skiprows=(n[i] + 1), max_rows=1)
-        q2 = pow(np.loadtxt(pdf_file, skiprows=(n[i] + 2), max_rows=1), 2)
-        flav = np.loadtxt(pdf_file, skiprows=(n[i] + 3), max_rows=1)
-        grid = np.loadtxt(pdf_file, skiprows=(n[i] + 4), max_rows=(n[i + 1] - n[i] - 4))
-        grids += [GridTuple(x, q2, flav, grid)]
-
-    return grids
 
 
 def _load_alphas(info_file):
@@ -186,11 +151,8 @@ class PDF:
         self.dirname = dirname
         self.fname = fname
         self.grids = []
-        info_file = os.path.join(self.dirname, self.fname, f"{fname}.info")
-
-        # Load the info file
-        with open(info_file, "r") as ifile:
-            self.info = yaml.load(ifile, Loader=yaml.FullLoader)
+        lhapdf_pdf = LHA_PDF(Path(self.dirname) / fname)
+        self.info = lhapdf_pdf.info
 
         if members is None:
             total_members = self.info.get("NumMembers", 1)
@@ -202,12 +164,7 @@ class PDF:
             logger.info("Loading %d members from %s", len(members), self.fname)
 
         for member_int in members:
-            member = str(member_int).zfill(4)
-            filename = os.path.join(self.dirname, fname, f"{fname}_{member}.dat")
-
-            logger.debug("Loading %s", filename)
-            grids = _load_data(filename)
-
+            grids = pdf.get_member_grids(member)
             subgrids = [Subgrid(grid, i, len(grids)) for i, grid in enumerate(grids)]
             self.grids.append(subgrids)
         self.members = members
@@ -240,24 +197,24 @@ class PDF:
 
     @property
     def q2max(self):
-        """ Upper boundary in q2 of the first grid """
+        """Upper boundary in q2 of the first grid"""
         q2max = self.grids[0][-1].log_q2max
         return np.exp(q2max)
 
     @property
     def q2min(self):
-        """ Lower boundary in q2 of the first grid """
+        """Lower boundary in q2 of the first grid"""
         q2min = self.grids[0][0].log_q2min
         return np.exp(q2min)
 
     @property
     def nmembers(self):
-        """ Number of members for this PDF """
+        """Number of members for this PDF"""
         return len(self.members)
 
     @property
     def active_members(self):
-        """ List of all member files """
+        """List of all member files"""
         member_list = []
         for member_int in self.members:
             member = str(member_int).zfill(4)

--- a/src/pdfflow/tests/test_alphas.py
+++ b/src/pdfflow/tests/test_alphas.py
@@ -34,7 +34,7 @@ def install_lhapdf(pdfset):
 SIZE = 200
 
 # Set up the PDF
-LIST_PDF = ["NNPDF31_nnlo_as_0118", "cteq6"]
+LIST_PDF = ["NNPDF31_nnlo_as_0118", "cteq61"]
 MEMBERS = 2
 DIRNAME = environment.datapath
 

--- a/src/pdfflow/tests/test_lhapdf.py
+++ b/src/pdfflow/tests/test_lhapdf.py
@@ -5,42 +5,45 @@
 """
 import pdfflow.pflow as pdf
 import logging
+from lhapdf_management import pdf_install
+from lhapdf_management.configuration import environment
 
 logger = logging.getLogger("pdfflow.test")
 
 import os
+
 # Run tests in CPU
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 import numpy as np
-import subprocess as sp
 
 try:
     import lhapdf
 except ModuleNotFoundError as e:
-    raise ModuleNotFoundError("Tests against alpha_s need an installation of LHAPDF")
-
-# Utility to install lhapdf sets
-def install_lhapdf(pdfset):
-    try:
-        lhapdf.mkPDF(pdfset)
-    except RuntimeError:
-        sp.run(['lhapdf', 'install', pdfset])
+    raise ModuleNotFoundError("Tests against lhapdf need an installation of LHAPDF")
 
 
 SIZE = 200
 
 # Set up the PDF
 LIST_PDF = [
-            "PDF4LHC15_nnlo_100",
-            "NNPDF31_nlo_as_0118", # some problem for the first bin
-            "MSTW2008lo68cl_nf3",
-            "NNPDF30_nnlo_as_0121_nf_6",
-            "cteq6"
-            ]
+    "PDF4LHC15_nnlo_100",
+    "NNPDF31_nlo_as_0118",  # some problem for the first bin
+    "MSTW2008lo68cl_nf3",
+    "NNPDF30_nnlo_as_0121_nf_6",
+    "cteq6",
+]
 MEMBERS = 2
-FLAVS = list(range(-3,4))
+FLAVS = list(range(-3, 4))
 FLAVS[FLAVS.index(0)] = 21
-DIRNAME = sp.run(['lhapdf-config', '--datadir'], stdout=sp.PIPE).stdout.strip().decode()
+DIRNAME = environment.datapath
+
+# Utility to install lhapdf sets
+def install_lhapdf(pdfset):
+    try:
+        lhapdf.mkPDF(pdfset)
+    except RuntimeError:
+        pdf_install(pdfset)
+
 
 # Install the pdfs if they don't exist
 for pdfset in LIST_PDF:
@@ -52,12 +55,13 @@ XARR = np.random.rand(SIZE)
 XARR[0] = 1e-10
 
 # Set up the Q2 arr
-QS = [ (1,10), (100, 10000), (10, 100)]
+QS = [(1, 10), (100, 10000), (10, 100)]
 
 # utilities
 def gen_q2(qmin, qmax):
-    """ generate an array of q2 between qmin and qmax """
-    return np.random.rand(SIZE)*(qmax-qmin) + qmin
+    """generate an array of q2 between qmin and qmax"""
+    return np.random.rand(SIZE) * (qmax - qmin) + qmin
+
 
 def dict_update(old_dict, new_dict):
     if not old_dict:
@@ -67,16 +71,18 @@ def dict_update(old_dict, new_dict):
         for key, item in new_dict.items():
             old_dict[key].append(item)
 
+
 def get_pdfvals(xarr, qarr, pdfset):
-    """ Get the pdf values from LHAPDF """
+    """Get the pdf values from LHAPDF"""
     lhapdf_pdf = lhapdf.mkPDF(pdfset)
     res = {}
     for x, q in zip(xarr, qarr):
         dict_update(res, lhapdf_pdf.xfxQ2(x, q))
     return res
 
+
 def test_accuracy(atol=1e-6):
-    """ Check the accuracy for all PDF sets for all members
+    """Check the accuracy for all PDF sets for all members
     in the lists LIST_PDF and MEMBERS
     for all defined ranges of Q for all flavours
     is better than atol.
@@ -84,6 +90,7 @@ def test_accuracy(atol=1e-6):
     This test doesnt care about Q extrapolation
     """
     import tensorflow as tf
+
     tf.config.experimental_run_functions_eagerly(True)
     for setname in LIST_PDF:
         for member in range(MEMBERS):
@@ -99,8 +106,9 @@ def test_accuracy(atol=1e-6):
                 flow_values = pdfflow.py_xfxQ2(FLAVS, XARR, q2arr)
                 lhapdf_values = get_pdfvals(XARR, q2arr, pdfset)
             for i, f in enumerate(FLAVS):
-                np.testing.assert_allclose(flow_values[:,i], lhapdf_values[f], atol=atol)
+                np.testing.assert_allclose(flow_values[:, i], lhapdf_values[f], atol=atol)
     tf.config.experimental_run_functions_eagerly(False)
+
 
 if __name__ == "__main__":
     test_accuracy()

--- a/src/pdfflow/tests/test_lhapdf.py
+++ b/src/pdfflow/tests/test_lhapdf.py
@@ -30,7 +30,7 @@ LIST_PDF = [
     "NNPDF31_nlo_as_0118",  # some problem for the first bin
     "MSTW2008lo68cl_nf3",
     "NNPDF30_nnlo_as_0121_nf_6",
-    "cteq6",
+    "cteq61",
 ]
 MEMBERS = 2
 FLAVS = list(range(-3, 4))

--- a/src/pdfflow/tests/test_pflow.py
+++ b/src/pdfflow/tests/test_pflow.py
@@ -84,7 +84,7 @@ def pdfflow_tester(pdf, members=None):
 
 
 def test_onemember():
-    """ Test the one-central-member of pdfflow """
+    """Test the one-central-member of pdfflow"""
     # Check the central member
     pdf = mkPDF(f"{PDFNAME}/0")
     pdfflow_tester(pdf)
@@ -97,7 +97,7 @@ def test_onemember():
 
 
 def test_multimember():
-    """ Test the multi-member capabilities of pdfflow """
+    """Test the multi-member capabilities of pdfflow"""
     run_eager(False)
     members = 5
     pdf = mkPDFs(PDFNAME, range(members))
@@ -108,7 +108,7 @@ def test_multimember():
 
 
 def test_one_multi():
-    """ Test that the multimember-I is indeed the same as just the Ith instance """
+    """Test that the multimember-I is indeed the same as just the Ith instance"""
     run_eager(True)
     pdf = mkPDF(f"{PDFNAME}/0")
     multi_pdf = mkPDFs(PDFNAME, [4, 0, 6])


### PR DESCRIPTION
This deals with #52 by using `lhapdf-management`, a python script for the management of LHAPDF sets (https://gitlab.com/hepcedar/lhapdf/-/merge_requests/12)

I don't plan to make the package much more complicated than what I've done already: https://pypi.org/project/lhapdf-management/ it has the basic features we need so that's it I guess.