### PR TITLE
upgrading c-api cmake

### DIFF
--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.0.2...3.28.1)
 
 # Use rpaths for now, previously there were issues with osx
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -13,25 +13,25 @@ project(libpdfflow)
 
 set(VERSION "\"0.1\"")
 
-find_package(PythonInterp 3 REQUIRED)
-find_package(PythonLibs   3 REQUIRED)
+find_package(Python3 COMPONENTS Interpreter Development)
 
 # running the cffi builder
 if (NOT EXISTS ${PROJECT_SOURCE_DIR/src/cpdfflow.cc})
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/build.py WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src)
+  execute_process(COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/build.py WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src)
 endif()
 
-include_directories(${PYTHON_INCLUDE_DIRS})
+include_directories(${Python3_INCLUDE_DIRS})
 include_directories(src)
 add_library(pdfflow SHARED ${PROJECT_SOURCE_DIR}/src/cpdfflow.c)
+target_link_libraries(pdfflow ${Python3_LIBRARIES})
 
 # pkg-config
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "${prefix}")
 set(includedir "${prefix}/include")
-set(extraincludirs "-I${PYTHON_INCLUDE_DIR}")
+set(extraincludirs "-I${Python3_INCLUDE_DIRS}")
 set(libdir "${prefix}/lib")
-set(pythonlibs "${PYTHON_LIBRARIES}")
+set(pythonlibs "${Python3_LIBRARIES}")
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/src/pdfflow.pc.in"

--- a/capi/README.md
+++ b/capi/README.md
@@ -21,10 +21,11 @@ pkg-config pdfflow --cflags
 pkg-config pdfflow --libs
 ```
 
-If you installed to a non-standard location, you need to set up the `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH`, e.g.:
+If you installed to a non-standard location, you need to set up the `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH`, e.g., for a `VIRTUAL_ENV`:
 ```bash
 export PKG_CONFIG_PATH=${VIRTUAL_ENV}/lib/pkgconfig/:${PKG_CONFIG_PATH}:
 export LD_LIBRARY_PATH=${VIRTUAL_ENV}/lib/:${LD_LIBRARY_PATH}:
+export DYLD_LIBRARY_PATH=${VIRTUAL_ENV}/lib:${DYLD_LIBRARY_PATH}Ñ
 ```
 
 

--- a/capi/README.md
+++ b/capi/README.md
@@ -25,7 +25,7 @@ If you installed to a non-standard location, you need to set up the `PKG_CONFIG_
 ```bash
 export PKG_CONFIG_PATH=${VIRTUAL_ENV}/lib/pkgconfig/:${PKG_CONFIG_PATH}:
 export LD_LIBRARY_PATH=${VIRTUAL_ENV}/lib/:${LD_LIBRARY_PATH}:
-export DYLD_LIBRARY_PATH=${VIRTUAL_ENV}/lib:${DYLD_LIBRARY_PATH}Ñ
+export DYLD_LIBRARY_PATH=${VIRTUAL_ENV}/lib:${DYLD_LIBRARY_PATH}:
 ```
 
 


### PR DESCRIPTION
This fixes compilation and installation issues on linux and mac, however on mac I cannot run the example using python3 from Xcode:
```
dyld[15376]: Library not loaded: @rpath/Python3.framework/Versions/3.9/Python3
  Reason: no LC_RPATH's found
Abort trap: 6
```

@scarlehoff does this works for you with homebrew?